### PR TITLE
Polish final benchmark documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,22 @@
 # build output
 bin/
 build/
+obj/
 *.o
+*.so
+*.a
 *.exe
 *.out
 
-# generated results and logs
+# local / temporary benchmark outputs
+work/
+logs/
+tmp/
+scratch/
+*.log
+slurm-*.out
+
+# generated implementation results
 results/data/*
 results/figures/*
 results/logs/*
@@ -14,33 +25,56 @@ results/scaling/*
 **/results/figures/*
 **/results/logs/*
 **/results/scaling/*
-*.log
+
+# heavy raw benchmark outputs that should not be committed
+comparison/results/split/
+comparison/results/raw/
+comparison/results/final/
+comparison/results/*_raw/
+comparison/results/tmp/
+
+# keep selected final report outputs tracked
+!comparison/results/final_clean/
+!comparison/results/final_clean/**
+!comparison/results/physics_fields/
+!comparison/results/physics_fields/**
+!comparison/figures/final_clean/
+!comparison/figures/final_clean/**
+!comparison/figures/report_pngs/
+!comparison/figures/report_pngs/**
+!comparison/figures/physics_final/
+!comparison/figures/physics_final/**
 
 # keep empty result folders visible on GitHub
 !results/**/.gitkeep
 !**/results/**/.gitkeep
 
-# python
+# Python
 __pycache__/
 *.pyc
+.pytest_cache/
 .venv/
+venv/
+jobs/python_new/
 .ipynb_checkpoints/
 
-# matlab
+# MATLAB / Simulink
 *.asv
 *.m~
+*.mex*
+*.slxc
+slprj/
+*.mat
+
+# packaged archives
+*.zip
+*.tar
+*.tar.gz
+*.7z
+dist/
 
 # editor/os
 .vscode/
 .idea/
 .DS_Store
 Thumbs.db
-
-# packaged archives
-dist/
-*.zip
-.pytest_cache/
-*.mex*
-*.slxc
-slprj/
-*.mat

--- a/README.md
+++ b/README.md
@@ -7,44 +7,41 @@
 ![CUDA](https://img.shields.io/badge/CUDA-GPU%20prototype-green)
 ![License](https://img.shields.io/badge/License-MIT-lightgrey)
 
-A solver-focused CFD benchmark for the two-dimensional incompressible lid-driven cavity problem.
+A solver-focused CFD/HPC benchmark for the two-dimensional incompressible lid-driven cavity problem.
 
-The goal is simple: keep the physical setup as consistent as possible, then compare how the same CFD problem behaves when it is implemented in MATLAB, Python, C, C++, OpenMP, MPI, and CUDA. This is not meant to be a commercial CFD solver. It is a portfolio and learning project for numerical methods, code structure, validation, and benchmark reporting.
+The project compares the same benchmark problem across MATLAB/Octave, Python, C, C++, OpenMP, MPI, and a CUDA prototype. The goal is not to build a production CFD package. The goal is to show numerical-method implementation, code structure, validation, performance measurement, and benchmark reporting across several programming models.
 
-## What this project shows
+## Highlights
 
-| Part | Role in the project |
-|---|---|
-| MATLAB/Octave | Reference workflow with looped and vectorized study options |
-| Python | Readable NumPy implementation plus a loop-style baseline |
-| C | Compiled serial CPU baseline |
-| C++ | Structured compiled-code baseline |
-| OpenMP | Shared-memory CPU threading for C and C++ |
-| MPI | Case-level parallel parameter studies |
-| CUDA | Single-GPU prototype |
-| Comparison tools | CSV matching, grid-convergence tables, validation plots, scaling plots, and reports |
+- SIMPLE-style pressure-correction workflow for a 2D incompressible lid-driven cavity.
+- Implementations in MATLAB/Octave, Python/NumPy, C, C++, OpenMP, MPI, and CUDA.
+- Parameter-study benchmark over grid size, Reynolds number, convection scheme, and pressure solver.
+- Runtime, residual, quality, and completion summaries.
+- Representative flow-field visualizations: streamlines, velocity vectors, velocity magnitude, pressure, vorticity, residual history, and Ghia centerline validation plots.
+- HPC-oriented Slurm scripts for running the benchmark on the Stromboli university cluster.
 
 ## Repository structure
 
 ```text
-matlab/          MATLAB/Octave reference implementation
+matlab/          MATLAB/Octave reference workflow
 python/          Python serial and MPI implementations
 c/               C serial, OpenMP, and MPI implementations
 cpp/             C++ serial, OpenMP, and MPI implementations
-cuda/            CUDA implementation for NVIDIA GPUs
-comparison/      comparison and reporting scripts
-docs/            project notes and running guides
+cuda/            CUDA prototype
+comparison/      comparison scripts, selected final tables, and report figures
+docs/            project notes and reporting guides
+jobs/            Slurm/HPC helper scripts
 scripts/         root-level helper scripts
 ```
 
-Most implementation folders follow the same layout:
+Most implementation folders follow this layout:
 
 ```text
-README.md        explains that implementation
-Makefile         common build/run commands
+README.md        notes for that implementation
+Makefile         build/run commands
 src/             solver source code
 postprocess/     plotting or post-processing scripts
-results/         generated outputs, mostly ignored by Git
+results/         generated local outputs, mostly ignored by Git
 ```
 
 ## Numerical benchmark
@@ -56,7 +53,7 @@ The benchmark is the classical lid-driven cavity flow:
 - no-slip side and bottom walls
 - incompressible flow
 - Reynolds-number based test cases
-- centerline velocity validation against the Ghia et al. benchmark data
+- centerline velocity validation against Ghia et al. benchmark data
 
 The solver follows a SIMPLE-style pressure-correction workflow:
 
@@ -65,7 +62,95 @@ The solver follows a SIMPLE-style pressure-correction workflow:
 3. solve the pressure-correction equation
 4. correct velocity and pressure
 5. calculate residuals and validation metrics
-6. export CSV files for comparison
+6. export CSV files for comparison and plotting
+
+## Final benchmark setup
+
+The full CPU benchmark was run on the Stromboli university cluster using this parameter sweep:
+
+| Parameter | Values |
+|---|---|
+| Grid size | `N = 32, 64, 128` |
+| Reynolds number | `Re = 100, 400, 1000` |
+| Convection schemes | `upwind`, `central` |
+| Pressure solvers | `RBGS`, `RBSOR` |
+| OpenMP setting | 4 threads |
+| MPI setting | case-level parameter-study distribution |
+
+The clean final results are stored in:
+
+```text
+comparison/results/final_clean/
+```
+
+The selected report figures are stored in:
+
+```text
+comparison/figures/report_pngs/
+comparison/figures/physics_final/
+comparison/figures/final_clean/
+```
+
+A more detailed result summary is available in:
+
+```text
+docs/FINAL_BENCHMARK_RESULTS.md
+```
+
+## Completion summary
+
+| Solver group | Completed cases | Status |
+|---|---:|---|
+| `c_serial` | 36 / 36 | complete |
+| `cpp_serial` | 36 / 36 | complete |
+| `c_openmp_t4` | 36 / 36 | complete |
+| `cpp_openmp_t4` | 36 / 36 | complete |
+| `python_vectorized` | 36 / 36 | complete |
+| `octave_vectorized` | 36 / 36 | complete |
+| `c_mpi` | 36 / 36 | complete |
+| `cpp_mpi` | 36 / 36 | complete |
+| `python_looped` | 20 / 36 | incomplete |
+| `octave_looped` | 34 / 36 | incomplete |
+| `python_mpi` | 36 / 72 | incomplete |
+
+Incomplete solvers are retained in the result tables for transparency, but the main fair ranking is based on complete solver groups.
+
+## Runtime ranking
+
+Median runtime over the collected cases:
+
+| Rank | Solver group | Median runtime [s] |
+|---:|---|---:|
+| 1 | `c_openmp_t4` | 236.76 |
+| 2 | `cpp_openmp_t4` | 284.40 |
+| 3 | `c_serial` | 486.39 |
+| 4 | `c_mpi` | 487.40 |
+| 5 | `cpp_mpi` | 630.38 |
+| 6 | `cpp_serial` | 631.80 |
+| 7 | `python_vectorized` | 1941.31 |
+| 8 | `octave_vectorized` | 2714.37 |
+
+The looped Python, looped Octave, and Python MPI runs are included in the CSV summaries, but they are not used for the fair complete-solver ranking because they did not finish the full expected case set.
+
+## Selected figures
+
+### Runtime comparison
+
+![Median runtime by solver](comparison/figures/report_pngs/02_median_runtime_complete_solvers_only.png)
+
+### Representative physics result
+
+![Streamlines](comparison/figures/physics_final/case_001_N128_Re1000_central_RBSOR_openmp_cpp_streamlines.png)
+
+### Ghia validation example
+
+![Ghia u validation](comparison/figures/physics_final/case_001_N128_Re1000_central_RBSOR_openmp_cpp_ghia_u.png)
+
+## Interpretation
+
+For this benchmark, the compiled C and C++ implementations were significantly faster than the Python and Octave workflows. The fastest complete implementation was `c_openmp_t4`, followed by `cpp_openmp_t4`.
+
+The C++ OpenMP implementation is the best practical direction for further CFD solver development because it combines strong performance with better structure and maintainability than plain C. Python remains useful for prototyping, automation, and post-processing. MPI in this repository represents case-level parameter-study parallelism, not domain decomposition.
 
 ## Quick start
 
@@ -82,77 +167,6 @@ For a larger CPU run:
 
 ```bash
 make quick-cpu
-```
-
-
-
-## Running on Stromboli
-
-The easiest Stromboli entry point is the all-in-one helper. It checks the available compilers/tools first, then runs only the parts that can actually run on that node. CUDA is included when `nvcc` and an accessible NVIDIA GPU are available.
-
-```bash
-bash scripts/run_stromboli_all.sh smoke
-# or
-make smoke-stromboli
-```
-
-For a longer run that survives a dropped SSH connection:
-
-```bash
-nohup bash scripts/run_stromboli_all.sh quick > stromboli_quick.log 2>&1 &
-tail -f stromboli_quick.log
-```
-
-To intentionally skip CUDA on a CPU-only login node:
-
-```bash
-RUN_CUDA=0 bash scripts/run_stromboli_all.sh quick
-```
-
-If CUDA is available on a different GPU node, run the CUDA folder there:
-
-```bash
-cd cuda
-make check-cuda
-make smoke
-make scaling
-```
-
-## Running the reference solver with GNU Octave
-
-The `matlab/` folder is now MATLAB/Octave-compatible. MATLAB is still supported, but on a university cluster such as Stromboli you can force GNU Octave:
-
-```bash
-cd matlab
-make smoke ENGINE=octave
-make quick ENGINE=octave
-```
-
-From the repository root, this also works:
-
-```bash
-ENGINE=octave make smoke-cpu
-ENGINE=octave make quick-cpu
-```
-
-There is also a Stromboli helper script:
-
-```bash
-bash scripts/run_stromboli_octave.sh smoke
-bash scripts/run_stromboli_octave.sh quick
-```
-
-For longer cluster runs:
-
-```bash
-nohup bash scripts/run_stromboli_octave.sh quick > octave_quick.log 2>&1 &
-tail -f octave_quick.log
-```
-
-By default, Octave runs skip figure generation because many cluster sessions are headless. The solver still writes CSV and `.mat` outputs. To force Octave figures, use:
-
-```bash
-OCTAVE_MAKE_FIGURES=1 bash scripts/run_stromboli_octave.sh quick
 ```
 
 Run one implementation directly:
@@ -183,6 +197,29 @@ cd cuda
 make smoke
 ```
 
+## Running on Stromboli
+
+The Stromboli helper scripts are kept in `jobs/` and `scripts/`. For a small check:
+
+```bash
+bash scripts/run_stromboli_all.sh smoke
+# or
+make smoke-stromboli
+```
+
+For a longer run that survives a dropped SSH connection:
+
+```bash
+nohup bash scripts/run_stromboli_all.sh quick > stromboli_quick.log 2>&1 &
+tail -f stromboli_quick.log
+```
+
+To intentionally skip CUDA on a CPU-only login node:
+
+```bash
+RUN_CUDA=0 bash scripts/run_stromboli_all.sh quick
+```
+
 ## Run modes
 
 | Mode | Meaning |
@@ -209,94 +246,13 @@ make compare-serial MODE=quick
 make report-serial MODE=quick
 ```
 
-The comparison output is written to:
-
-```text
-comparison/results/
-```
-
 Cases are matched by setup, not by run order:
 
 ```text
 mesh size, Reynolds number, convection scheme, pressure solver
 ```
 
-
-## Automated studies and plots
-
-Run a grid-convergence study from the repository root:
-
-```bash
-make grid-convergence
-```
-
-The default command runs the C++ serial solver for `N=32,64,128` at `Re=100` and writes:
-
-```text
-comparison/results/grid_convergence/
-```
-
-You can also call the script directly, for example:
-
-```bash
-python3 scripts/run_grid_convergence.py --solver cpp --N-list 32,64,128 --Re 100 --scheme upwind --pressure RBGS
-python3 scripts/run_grid_convergence.py --solver python --implementation serial_python_vectorized --N-list 32,64
-```
-
-The observed order is calculated from the Ghia centerline L2 errors. This is useful for a portfolio benchmark, but it should be described as a benchmark-data convergence check, not a manufactured-solution proof.
-
-Create automatic U/V centerline validation plots against the Ghia data:
-
-```bash
-make validation-plots
-python3 scripts/plot_validation_centerlines.py --Re 100 --N 64 --scheme upwind --pressure RBGS
-```
-
-The plots are written to:
-
-```text
-comparison/results/figures/validation/
-```
-
-Run OpenMP, MPI, or CUDA scaling/performance checks:
-
-```bash
-make scaling-openmp
-make scaling-mpi MODE=quick
-make scaling-cuda
-make scaling-all MODE=quick
-```
-
-OpenMP scaling is strong scaling for one fixed CPU case. MPI scaling is case-level scaling for a parameter sweep, not domain decomposition. CUDA uses a block-size performance sweep for the GPU prototype, so it should be presented as GPU tuning rather than classical strong scaling. The scaling CSV and plots are written under:
-
-```text
-comparison/results/scaling/
-comparison/results/figures/scaling/
-```
-
 ## Important scope notes
-
-### C labels
-
-C is kept as one compiled serial baseline. Older output labels such as `serial_c_looped` or `serial_c_vectorized` are accepted only for backward compatibility. They do not represent two different C algorithms.
-
-### OpenMP, MPI, and looped/vectorized labels
-
-Do not describe every OpenMP/MPI solver as having both looped and vectorized versions. The honest split is:
-
-| Solver family | Looped/vectorized status |
-|---|---|
-| MATLAB/Octave | Reference workflow keeps loop-style and vectorized study options |
-| Python serial | Has NumPy/vectorized-style and loop-style implementations |
-| Python MPI | Distributes the Python case list, so it can run both Python implementation labels |
-| C serial | One compiled baseline only |
-| C OpenMP | One threaded C baseline only |
-| C MPI | One case-parallel C baseline only |
-| C++ serial | One compiled C++ baseline only |
-| C++ OpenMP | One threaded C++ baseline only |
-| C++ MPI | One case-parallel C++ baseline only |
-
-The compiler may auto-vectorize some C/C++ loops with optimization flags, but that is not the same as maintaining a separate vectorized algorithm.
 
 ### MPI
 
@@ -312,7 +268,7 @@ The CUDA version is a GPU prototype. It is useful for learning and comparison, b
 
 ### Numerical differences
 
-Small differences between languages are expected. The goal is not bit-for-bit identical output. The important checks are velocity fields, centerline profiles, residual trends, validation error, and runtime behaviour.
+Small differences between languages are expected. The goal is not bit-for-bit identical output. The important checks are velocity fields, centerline profiles, residual trends, validation metrics, and runtime behaviour.
 
 ## Requirements
 
@@ -336,7 +292,7 @@ Optional tools:
 MATLAB with batch mode support, or GNU Octave for the reference solver
 OpenMPI or another MPI implementation
 mpi4py for Python MPI
-NVIDIA GPU + CUDA toolkit for CUDA. On CPU-only nodes, CUDA commands are skipped by `scripts/run_stromboli_all.sh`.
+NVIDIA GPU + CUDA toolkit for CUDA
 ```
 
 On Windows, WSL or a Linux-style terminal is recommended because the helper scripts and Makefiles are written for Linux/HPC-style usage.
@@ -345,6 +301,7 @@ On Windows, WSL or a Linux-style terminal is recommended because the helper scri
 
 | File | Why it matters |
 |---|---|
+| `docs/FINAL_BENCHMARK_RESULTS.md` | Final benchmark summary and interpretation |
 | `docs/PROJECT_OVERVIEW.md` | Short numerical and project summary |
 | `docs/IMPLEMENTATION_LAYOUT.md` | Standard folder layout across implementations |
 | `docs/RESULTS_GUIDE.md` | Explanation of generated CSV and plot files |
@@ -352,16 +309,20 @@ On Windows, WSL or a Linux-style terminal is recommended because the helper scri
 | `docs/HOW_TO_PRESENT_THIS_PROJECT.md` | Honest wording for CV, LinkedIn, or interviews |
 | `comparison/README.md` | How the comparison scripts are used |
 
-## Current status
+## References
 
-The repository is prepared as a clean comparison hub. The next practical step is to run the full benchmark set on the university machine, then add a small number of selected final plots and tables to this README.
+- Ghia, U., Ghia, K. N., and Shin, C. T. (1982). High-Re solutions for incompressible flow using the Navier-Stokes equations and a multigrid method. *Journal of Computational Physics*, 48(3), 387-411.
+- Patankar, S. V. (1980). *Numerical Heat Transfer and Fluid Flow*. Hemisphere Publishing.
+- Versteeg, H. K., and Malalasekera, W. (2007). *An Introduction to Computational Fluid Dynamics: The Finite Volume Method*. Pearson.
+- Ferziger, J. H., Peric, M., and Street, R. L. (2020). *Computational Methods for Fluid Dynamics*. Springer.
 
-## Roadmap
+## Author
 
-- Run the full benchmark on a stronger machine
-- Add one selected runtime table
-- Add one validation table
-- Add one residual plot
-- Add one velocity or streamline plot
-- Add OpenMP and MPI scaling discussion
-- Add later extensions such as LBM or OpenFOAM as separate projects
+Ahmed Kandil
+
+- Email: a.akandil@outlook.com
+- GitHub: [Kandil2001](https://github.com/Kandil2001)
+- Portfolio: [kandil2001.github.io](https://kandil2001.github.io)
+- LinkedIn: [ahmed-kandil03](https://www.linkedin.com/in/ahmed-kandil03/)
+
+Released under the MIT License.

--- a/comparison/results/final/completeness_summary.csv
+++ b/comparison/results/final/completeness_summary.csv
@@ -1,8 +1,8 @@
 solver_group,rows_found,expected_rows,complete,missing_case_ids
 c_serial,36,36,True,none
 cpp_serial,36,36,True,none
-c_openmp,0,36,False,none
-cpp_openmp,0,36,False,none
+c_openmp_t4,36,36,True,none
+cpp_openmp_t4,36,36,True,none
 python_vectorized,36,36,True,none
 python_looped,20,36,False,15 19 21 23 25 26 27 28 29 30 31 32 33 34 35 36
 octave_vectorized,36,36,True,none

--- a/docs/FINAL_BENCHMARK_RESULTS.md
+++ b/docs/FINAL_BENCHMARK_RESULTS.md
@@ -1,0 +1,158 @@
+# Final Benchmark Results
+
+This document summarizes the final CPU benchmark run for the lid-driven cavity solver comparison project.
+
+## Benchmark scope
+
+The benchmark compares the same 2D incompressible lid-driven cavity problem across multiple implementations and programming models.
+
+| Parameter | Values |
+|---|---|
+| Grid size | `N = 32, 64, 128` |
+| Reynolds number | `Re = 100, 400, 1000` |
+| Convection schemes | `upwind`, `central` |
+| Pressure solvers | `RBGS`, `RBSOR` |
+| OpenMP setting | 4 threads |
+| MPI setting | case-level parameter-study distribution |
+
+The benchmark was run on the Stromboli university cluster. The final clean results are stored in:
+
+```text
+comparison/results/final_clean/
+```
+
+Selected final figures are stored in:
+
+```text
+comparison/figures/report_pngs/
+comparison/figures/final_clean/
+comparison/figures/physics_final/
+```
+
+## Completion summary
+
+| Solver group | Completed cases | Status |
+|---|---:|---|
+| `c_serial` | 36 / 36 | complete |
+| `cpp_serial` | 36 / 36 | complete |
+| `c_openmp_t4` | 36 / 36 | complete |
+| `cpp_openmp_t4` | 36 / 36 | complete |
+| `python_vectorized` | 36 / 36 | complete |
+| `octave_vectorized` | 36 / 36 | complete |
+| `c_mpi` | 36 / 36 | complete |
+| `cpp_mpi` | 36 / 36 | complete |
+| `python_looped` | 20 / 36 | incomplete |
+| `octave_looped` | 34 / 36 | incomplete |
+| `python_mpi` | 36 / 72 | incomplete |
+
+The incomplete solvers are kept in the result tables for transparency. They are not used for the main complete-solver ranking.
+
+## Runtime summary
+
+Median runtime over collected cases:
+
+| Rank | Solver group | Rows | Median runtime [s] |
+|---:|---|---:|---:|
+| 1 | `c_openmp_t4` | 36 | 236.76 |
+| 2 | `cpp_openmp_t4` | 36 | 284.40 |
+| 3 | `c_serial` | 36 | 486.39 |
+| 4 | `c_mpi` | 36 | 487.40 |
+| 5 | `cpp_mpi` | 36 | 630.38 |
+| 6 | `cpp_serial` | 36 | 631.80 |
+| 7 | `python_mpi` | 36 | 1581.02 |
+| 8 | `python_vectorized` | 36 | 1941.31 |
+| 9 | `octave_vectorized` | 36 | 2714.37 |
+| 10 | `python_looped` | 20 | 4820.14 |
+| 11 | `octave_looped` | 34 | 6611.03 |
+
+For a fair complete-solver ranking, use only the completed groups:
+
+1. `c_openmp_t4`
+2. `cpp_openmp_t4`
+3. `c_serial`
+4. `c_mpi`
+5. `cpp_mpi`
+6. `cpp_serial`
+7. `python_vectorized`
+8. `octave_vectorized`
+
+## Convergence and validation summary
+
+The clean result tables include `AvgPoissonRelResidual` and quality labels. Most complete solvers show essentially the same residual pattern because they solve the same benchmark cases.
+
+For the main complete solvers, the median `AvgPoissonRelResidual` is approximately:
+
+```text
+9.30e-05
+```
+
+The quality labels are stored in:
+
+```text
+comparison/results/final_clean/quality_counts_by_solver.csv
+```
+
+For the complete C/C++/Python-vectorized groups, the quality split is mostly:
+
+```text
+14 cases: needs_improvement
+22 cases: validated_but_not_converged
+```
+
+This should be interpreted honestly: the benchmark is useful for comparing implementation behaviour and runtime, but some cases reach the maximum iteration limit before full convergence. The result plots and tables therefore emphasize both performance and numerical quality.
+
+## Representative physics outputs
+
+Representative C++ OpenMP field outputs were generated for selected cases and stored in:
+
+```text
+comparison/results/physics_fields/
+comparison/figures/physics_final/
+```
+
+These figures include:
+
+- velocity magnitude contours
+- pressure contours
+- vorticity contours
+- streamlines
+- velocity vector fields
+- residual histories
+- Ghia centerline validation plots for `u(y)` and `v(x)`
+
+The representative high-resolution example uses:
+
+```text
+N = 128
+Re = 1000
+Scheme = central
+Pressure solver = RBSOR
+Implementation = C++ OpenMP
+```
+
+## Main interpretation
+
+For this lid-driven cavity benchmark, the compiled implementations were much faster than the interpreted workflows. The fastest complete implementation was `c_openmp_t4`, followed by `cpp_openmp_t4`.
+
+C OpenMP gave the best raw runtime. C++ OpenMP is the best practical direction for further solver development because it combines strong performance with cleaner structure and better maintainability than plain C.
+
+Python remains valuable for prototyping, automation, and post-processing. Pure Python loops and looped Octave are not suitable for heavy CFD parameter sweeps without further acceleration.
+
+The MPI implementations in this repository are case-level parameter-study parallel implementations. They distribute independent benchmark cases across ranks. They are useful for running a sweep faster, but they are not domain-decomposition CFD solvers.
+
+## Recommended project wording
+
+A concise professional description for this repository:
+
+> Multi-language CFD/HPC benchmark for the 2D lid-driven cavity problem, comparing MATLAB/Octave, Python, C, C++, OpenMP, MPI, and CUDA-style workflows with runtime tables, residual summaries, Ghia validation plots, and representative flow-field visualizations.
+
+## Files to cite or show first
+
+| File/folder | Purpose |
+|---|---|
+| `comparison/results/final_clean/runtime_summary_fixed.csv` | final runtime ranking |
+| `comparison/results/final_clean/completeness_summary_fixed.csv` | completed vs incomplete solver groups |
+| `comparison/results/final_clean/residual_summary_by_solver.csv` | residual/convergence summary |
+| `comparison/results/final_clean/quality_counts_by_solver.csv` | quality-category summary |
+| `comparison/figures/report_pngs/` | report-level runtime/residual/completeness plots |
+| `comparison/figures/physics_final/` | streamlines, contours, vectors, and validation plots |


### PR DESCRIPTION
This PR makes the final benchmark presentation cleaner and more professional.

Changes:
- Rewrites the main README around the completed benchmark results.
- Adds final runtime/completion/interpretation sections.
- Adds selected figure previews for runtime, streamlines, and Ghia validation.
- Adds `docs/FINAL_BENCHMARK_RESULTS.md` with a detailed final results summary.
- Tightens `.gitignore` to avoid future raw/heavy generated outputs.
- Corrects the legacy `comparison/results/final/completeness_summary.csv` so it no longer shows the old OpenMP naming issue.

Notes:
- The clean source of truth remains `comparison/results/final_clean/`.
- The old `comparison/results/final/` folder is treated as legacy intermediate output.