### PR TITLE
Add professional repository metadata and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/benchmark_result.md
+++ b/.github/ISSUE_TEMPLATE/benchmark_result.md
@@ -1,0 +1,47 @@
+---
+name: Benchmark result or validation note
+about: Discuss a benchmark result, validation plot, residual trend, or performance observation
+title: "[Benchmark]: "
+labels: benchmark
+assignees: ""
+---
+
+## Result or observation
+
+Describe the benchmark result or validation observation.
+
+## Affected implementation
+
+- [ ] MATLAB/Octave
+- [ ] Python serial
+- [ ] Python MPI
+- [ ] C serial
+- [ ] C OpenMP
+- [ ] C MPI
+- [ ] C++ serial
+- [ ] C++ OpenMP
+- [ ] C++ MPI
+- [ ] CUDA
+- [ ] Comparison/reporting scripts
+
+## Case setup
+
+| Parameter | Value |
+|---|---|
+| Grid size `N` | |
+| Reynolds number `Re` | |
+| Scheme | |
+| Pressure solver | |
+| Threads/ranks | |
+
+## Evidence
+
+Attach or reference the relevant CSV, PNG, table, or command output.
+
+## Interpretation
+
+What do you think this result means?
+
+## Suggested next step
+
+What should be checked or improved?

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,53 @@
+---
+name: Bug report
+about: Report a reproducible problem in the code, build system, scripts, or documentation
+title: "[Bug]: "
+labels: bug
+assignees: ""
+---
+
+## Problem
+
+Describe the problem clearly.
+
+## Where it happens
+
+Affected area:
+
+- [ ] MATLAB/Octave
+- [ ] Python
+- [ ] C
+- [ ] C++
+- [ ] OpenMP
+- [ ] MPI
+- [ ] CUDA
+- [ ] Comparison scripts
+- [ ] Documentation
+- [ ] HPC/Slurm scripts
+
+## Steps to reproduce
+
+```bash
+# paste the command(s) here
+```
+
+## Expected behaviour
+
+What did you expect to happen?
+
+## Actual behaviour
+
+What happened instead?
+
+## Environment
+
+- OS / cluster:
+- Compiler:
+- Python version:
+- MPI version, if relevant:
+- CUDA version, if relevant:
+- MATLAB or Octave version, if relevant:
+
+## Logs or output
+
+Paste only the relevant part.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security report
+    url: mailto:a.akandil@outlook.com
+    about: Please report security issues privately by email.
+  - name: Project overview
+    url: https://github.com/Kandil2001/LidCavity_Solver_Comparison/blob/main/docs/FINAL_BENCHMARK_RESULTS.md
+    about: Read the final benchmark summary before opening result interpretation issues.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+## Summary
+
+Describe the change briefly.
+
+## Type of change
+
+- [ ] Documentation
+- [ ] Bug fix
+- [ ] Solver implementation
+- [ ] Post-processing / plotting
+- [ ] Benchmark result update
+- [ ] Build / HPC script update
+
+## Numerical impact
+
+Does this change affect numerical results?
+
+- [ ] No numerical impact
+- [ ] Yes, numerical results may change
+- [ ] Not sure
+
+If yes, describe what changed and which implementation is affected.
+
+## Checks performed
+
+- [ ] I ran a smoke test where possible
+- [ ] I checked generated files are not unnecessarily large
+- [ ] I updated documentation if needed
+- [ ] I kept raw temporary outputs out of Git
+
+## Notes
+
+Add any limitations, assumptions, or follow-up work here.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - python

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,23 @@
+cff-version: 1.2.0
+title: "Lid-Driven Cavity Solver Comparison"
+message: "If you use this repository for learning, benchmarking, or comparison, please cite it using this metadata."
+type: software
+authors:
+  - family-names: Kandil
+    given-names: Ahmed
+repository-code: "https://github.com/Kandil2001/LidCavity_Solver_Comparison"
+url: "https://github.com/Kandil2001/LidCavity_Solver_Comparison"
+license: MIT
+keywords:
+  - CFD
+  - lid-driven cavity
+  - numerical methods
+  - high-performance computing
+  - OpenMP
+  - MPI
+  - CUDA
+  - Python
+  - C++
+  - MATLAB
+abstract: "A multi-language CFD/HPC benchmark for the two-dimensional incompressible lid-driven cavity problem, comparing MATLAB/Octave, Python, C, C++, OpenMP, MPI, and CUDA-style workflows."
+date-released: "2026-06-25"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,83 @@
+# Contributing
+
+Thank you for your interest in contributing to this lid-driven cavity CFD benchmark.
+
+This project is primarily a portfolio and learning project, so contributions should keep the repository clear, reproducible, and scientifically honest.
+
+## Good contribution areas
+
+Useful contributions include:
+
+- fixing build or runtime issues
+- improving documentation
+- improving reproducibility on Linux/HPC systems
+- adding small validation or plotting improvements
+- improving post-processing scripts
+- adding benchmark cases in a controlled way
+- improving code clarity without changing numerical behaviour silently
+
+## Before changing solver behaviour
+
+If a change affects numerical results, please document:
+
+- which implementation is affected
+- what changed numerically
+- whether the change affects runtime
+- whether the change affects validation against Ghia data
+- whether previous benchmark tables need to be regenerated
+
+## Development workflow
+
+1. Create a feature branch.
+2. Make focused changes.
+3. Run a smoke test when possible.
+4. Keep generated temporary outputs out of Git.
+5. Open a pull request with a clear summary.
+
+Example smoke commands:
+
+```bash
+make smoke-cpu
+```
+
+or for one implementation:
+
+```bash
+cd cpp/serial
+make smoke
+```
+
+## Generated files
+
+Do not commit large raw result folders, temporary work folders, build products, local logs, or packaged archives.
+
+The important final report folders currently kept in Git are:
+
+```text
+comparison/results/final_clean/
+comparison/results/physics_fields/
+comparison/figures/final_clean/
+comparison/figures/report_pngs/
+comparison/figures/physics_final/
+```
+
+## Code style
+
+General expectations:
+
+- use readable names
+- avoid unnecessary complexity
+- keep implementation-specific changes inside the relevant folder
+- document assumptions near the code that uses them
+- avoid claiming exact equivalence across languages unless it is actually verified
+
+## Scientific honesty
+
+This repository should be presented as a benchmark and learning project, not as a production-grade CFD solver.
+
+Important scope notes:
+
+- MPI is currently case-level parameter-study parallelism, not domain decomposition.
+- CUDA is a prototype and should be compared carefully.
+- Some cases reach the maximum iteration limit before full convergence.
+- Incomplete solver groups are retained for transparency but should not be used for the fair complete-solver ranking.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,47 @@
+# Security Policy
+
+This repository is an educational CFD/HPC benchmark project. It is not a production service and does not process sensitive user data by design.
+
+## Supported versions
+
+Security updates are applied to the default branch:
+
+| Branch | Supported |
+|---|---|
+| `main` | yes |
+| old feature branches | no |
+
+## Reporting a vulnerability
+
+If you find a security issue in this repository, please do **not** open a public issue with exploit details.
+
+Instead, contact the maintainer privately:
+
+- Email: a.akandil@outlook.com
+
+Please include:
+
+- a short description of the issue
+- affected file or workflow
+- steps to reproduce, if safe to share
+- possible impact
+
+## Scope
+
+Relevant security concerns include:
+
+- unsafe shell commands in scripts
+- accidental credential exposure
+- unsafe download or setup scripts
+- dependency issues in reproducible environments
+- malicious or unexpected behaviour in helper scripts
+
+Out of scope:
+
+- numerical accuracy disagreements
+- performance differences between implementations
+- expected crashes caused by unsupported compilers, missing MPI, missing CUDA, or incompatible MATLAB/Octave installations
+
+## Dependency note
+
+The repository uses Python, compiler toolchains, MPI, optional MATLAB/Octave, and optional CUDA. Users should install dependencies from trusted sources and review setup scripts before running them on shared HPC systems.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,25 @@
+# Support
+
+This is an educational CFD/HPC benchmark repository. Support is provided on a best-effort basis.
+
+## Best ways to ask for help
+
+Use GitHub Issues for:
+
+- reproducible build problems
+- documentation mistakes
+- plotting or post-processing issues
+- benchmark interpretation questions
+- suggestions for clearer result presentation
+
+Please include:
+
+- operating system or cluster environment
+- compiler and Python versions
+- the command you ran
+- the relevant error message or output
+- affected implementation folder, if known
+
+## Security issues
+
+Please do not open public issues for security concerns. See [`SECURITY.md`](SECURITY.md).

--- a/docs/WIKI_INDEX.md
+++ b/docs/WIKI_INDEX.md
@@ -1,0 +1,43 @@
+# Documentation Index
+
+This repository keeps project documentation in `docs/` so it works like a lightweight wiki directly inside GitHub.
+
+## Start here
+
+| Document | Purpose |
+|---|---|
+| [`FINAL_BENCHMARK_RESULTS.md`](FINAL_BENCHMARK_RESULTS.md) | Final benchmark results, interpretation, and important output folders |
+| [`PROJECT_OVERVIEW.md`](PROJECT_OVERVIEW.md) | Short project and numerical-method overview |
+| [`IMPLEMENTATION_LAYOUT.md`](IMPLEMENTATION_LAYOUT.md) | Folder layout and implementation structure |
+| [`RESULTS_GUIDE.md`](RESULTS_GUIDE.md) | Explanation of result files, CSV outputs, and plots |
+| [`RUNNING_ON_HPC.md`](RUNNING_ON_HPC.md) | Notes for running on Linux/HPC environments |
+| [`HOW_TO_PRESENT_THIS_PROJECT.md`](HOW_TO_PRESENT_THIS_PROJECT.md) | Honest wording for CV, LinkedIn, interviews, and portfolio use |
+
+## Main result folders
+
+| Folder | Purpose |
+|---|---|
+| `comparison/results/final_clean/` | Clean final CSV summaries |
+| `comparison/results/physics_fields/` | Representative physics field CSVs |
+| `comparison/figures/report_pngs/` | Runtime, completeness, residual, and speedup figures |
+| `comparison/figures/physics_final/` | Streamlines, vectors, contours, residuals, and Ghia validation plots |
+| `comparison/figures/final_clean/` | Additional clean final figures |
+
+## Project governance files
+
+| File | Purpose |
+|---|---|
+| [`../LICENSE`](../LICENSE) | MIT license |
+| [`../SECURITY.md`](../SECURITY.md) | Security reporting policy |
+| [`../CONTRIBUTING.md`](../CONTRIBUTING.md) | Contribution and scientific-honesty guidelines |
+| [`../CITATION.cff`](../CITATION.cff) | Citation metadata |
+| [`../.github/PULL_REQUEST_TEMPLATE.md`](../.github/PULL_REQUEST_TEMPLATE.md) | Pull request checklist |
+| [`../.github/ISSUE_TEMPLATE/`](../.github/ISSUE_TEMPLATE/) | Issue templates |
+
+## Suggested reader path
+
+1. Read the root `README.md` for the project story.
+2. Read `FINAL_BENCHMARK_RESULTS.md` for the benchmark conclusion.
+3. Check `comparison/figures/report_pngs/` for runtime and residual figures.
+4. Check `comparison/figures/physics_final/` for streamlines, vectors, contours, and validation plots.
+5. Read `HOW_TO_PRESENT_THIS_PROJECT.md` before using the project on LinkedIn, CV, or interviews.


### PR DESCRIPTION
Adds professional GitHub repository files:

- `SECURITY.md` for private vulnerability reporting.
- `CONTRIBUTING.md` with benchmark-change and scientific-honesty guidelines.
- `SUPPORT.md` for how to ask for help.
- `CITATION.cff` for citation metadata.
- GitHub issue templates for bugs and benchmark-result discussions.
- Pull request checklist.
- Dependabot configuration for monthly Python dependency checks.
- `docs/WIKI_INDEX.md` as a lightweight documentation/wiki index.

Note: creating a code-of-conduct file was blocked by the connector safety layer, so it was not included in this PR.