### PR TITLE
Prepare reproducible paper benchmark foundation

### DIFF
--- a/benchmark/NUMERICAL_SPECIFICATION.md
+++ b/benchmark/NUMERICAL_SPECIFICATION.md
@@ -1,0 +1,183 @@
+# Paper numerical specification
+
+This document defines the first publishable benchmark target. It is intentionally narrower than the full repository so that every reported comparison uses one clear numerical method and one fair stopping protocol.
+
+## Paper question
+
+How consistently and efficiently can the same simple two-dimensional incompressible lid-driven-cavity algorithm be implemented in Python, C, C++, and, when available, Rust?
+
+OpenFOAM is included only as an external engineering reference. The existing MATLAB and Octave implementations remain available in the repository but are not part of the main Stromboli benchmark.
+
+## Fixed physical problem
+
+- Square cavity with side length `L = 1`
+- Top-lid velocity `U = 1`
+- No-slip stationary side and bottom walls
+- Constant density `rho = 1`
+- Double precision
+- Reynolds numbers `100`, `400`, and `1000`
+
+## Fixed numerical method
+
+The in-house implementations use an explicit pseudo-time pressure-correction method on a uniform Cartesian grid:
+
+1. Apply velocity boundary conditions.
+2. Compute a stable pseudo-time step.
+3. Predict the velocity field.
+4. Compute predicted-velocity divergence.
+5. Solve the pressure-correction Poisson equation using red-black SOR.
+6. Correct velocity and update pressure.
+7. Reapply boundary conditions.
+8. Compute velocity-update, divergence, and pressure-solver metrics.
+9. Repeat until every required convergence criterion is satisfied.
+
+The method must be described consistently as an explicit pressure-correction or projection-style method. It must not be presented as a new algorithm or as a full finite-volume SIMPLE implementation.
+
+## Main case matrix
+
+The first paper matrix uses:
+
+- Grid sizes: `33`, `65`, `129`, `257`
+- Reynolds numbers: `100`, `400`, `1000`
+- Convection: central difference
+- Diffusion: central difference
+- Pressure solver: red-black SOR
+
+This gives 12 primary cases per serial implementation. Odd grid sizes place the geometric centerlines exactly on grid lines.
+
+Upwind and RBGS cases remain useful for development and sensitivity analysis, but they are not part of the main cross-language runtime ranking.
+
+## Initial convergence targets
+
+The draft targets are:
+
+- Maximum velocity update: `1e-8`
+- Maximum discrete divergence: `1e-6`
+- Pressure Poisson relative residual: `1e-8`
+- Pressure solve must converge during the final outer iteration
+
+These values are provisional. A tolerance-sensitivity study must confirm that tightening them further does not materially change the centerline velocities or vortex location.
+
+Reaching the maximum iteration count is never convergence.
+
+## Required status fields
+
+Every result row must contain separate fields for:
+
+- `ExecutionStatus`
+- `OuterConverged`
+- `PressureConverged`
+- `ValidationStatus`
+
+A completed process may therefore still be marked as numerically unconverged.
+
+The current `Ru` and `Rv` quantities should be renamed to `VelocityUpdateU` and `VelocityUpdateV`, because they measure changes between consecutive fields rather than residuals of the discretized momentum equations.
+
+## Validation and verification
+
+### Cavity validation
+
+For each converged case, report:
+
+- Exact `u(y)` profile at `x = 0.5`
+- Exact `v(x)` profile at `y = 0.5`
+- L1, L2, and Linf errors against Ghia et al.
+- Primary-vortex center and velocity or streamfunction measure
+- Grid trend across all available resolutions
+
+Validation thresholds must not be used as substitutes for convergence.
+
+### Code verification
+
+Before final timing runs, add tests for:
+
+- First derivatives of analytical polynomial fields
+- Laplacian of an analytical field
+- Divergence of an analytical divergence-free field
+- Vorticity of an analytical field
+- Pressure Poisson solution with a known analytical answer
+- Boundary-condition application
+
+The tests should show the expected discretization order under systematic grid refinement.
+
+## Cross-language equivalence
+
+The C++ serial implementation is the initial numerical reference. Once it converges reliably, the same case must be reproduced in C, Python, and optional Rust.
+
+For matched converged fields, report differences in:
+
+- `u`, `v`, and speed L1/L2/Linf norms
+- Mean-centered pressure norms
+- Maximum divergence
+- Centerline profiles
+- Outer-iteration count
+- Total pressure iterations
+
+Serial and shared-memory versions must agree within documented floating-point tolerances before they are timed.
+
+## Language and software scope
+
+### Core serial implementations
+
+- Python/NumPy
+- C
+- C++
+
+### Conditional serial implementation
+
+- Rust, only after `rustc` and `cargo` availability is confirmed on Stromboli or a reproducible user-space toolchain is established
+
+### Shared-memory comparison
+
+- C/OpenMP
+- C++/OpenMP
+- Rust/Rayon when Rust is available
+
+### MPI
+
+The current MPI drivers distribute independent cases. They must be evaluated as parameter-sweep throughput using total study wall time and cases per hour. They are not domain-decomposed CFD solvers.
+
+### OpenFOAM
+
+OpenFOAM is an external reference for centerline accuracy, vortex structure, and end-to-end runtime. It must be plotted separately from the identical-algorithm language ranking.
+
+### Excluded from the first paper
+
+- MATLAB and Octave, because they are unavailable on the target Stromboli environment
+- CUDA, until an algorithmically equivalent pressure solve is available
+
+## Timing protocol
+
+Final timing runs must:
+
+- Use only converged cases
+- Run on the same node type
+- Record hostname, CPU, compiler/interpreter version, commit SHA, thread count, and rank count
+- Disable field output inside the timed solver section
+- Use one warm-up and at least five measured repetitions
+- Preserve every individual timing result
+- Report median and interquartile range
+- Report solver time separately from output and total process time
+
+## Existing long-running jobs
+
+Jobs started before this specification should be allowed to finish and archived as `pilot_v0`. They are useful for diagnosing convergence and estimating runtime, but they must not be included in the final paper ranking unless they are rerun under the frozen specification.
+
+## First acceptance milestone
+
+The first milestone is one C++ serial case:
+
+```text
+N = 65
+Re = 100
+Convection = central
+Pressure solver = RBSOR
+```
+
+It must:
+
+- satisfy all convergence criteria;
+- produce a stable pressure residual history;
+- match the Ghia centerlines within a documented error;
+- export complete metadata;
+- reproduce consistently in repeated runs.

--- a/benchmark/paper_cases.yaml
+++ b/benchmark/paper_cases.yaml
@@ -1,0 +1,127 @@
+schema_version: 1
+status: draft
+purpose: >-
+  Reproducible cross-language benchmark of one simple two-dimensional
+  incompressible lid-driven-cavity pressure-correction algorithm.
+
+paper_scope:
+  core_serial:
+    required:
+      - python_serial
+      - c_serial
+      - cpp_serial
+    conditional:
+      - rust_serial
+  shared_memory:
+    required:
+      - c_openmp
+      - cpp_openmp
+    conditional:
+      - rust_rayon
+  throughput_parallelism:
+    - c_mpi
+    - cpp_mpi
+    - python_mpi
+  external_reference:
+    - openfoam
+  excluded_from_main_paper:
+    - matlab
+    - octave
+    - cuda
+
+scope_notes:
+  matlab_octave: >-
+    Existing MATLAB and Octave implementations remain in the repository, but
+    are excluded from the main paper benchmark because the target Stromboli
+    environment does not provide them.
+  rust: >-
+    Rust is included only when rustc and cargo are available on the target
+    machine or can be installed in user space without changing the benchmark
+    hardware.
+  openfoam: >-
+    OpenFOAM is an external engineering reference. It is compared for solution
+    quality and end-to-end runtime, not as an identical implementation of the
+    in-house pressure-correction algorithm.
+  mpi: >-
+    Current MPI implementations distribute independent cases. Results must be
+    reported as parameter-sweep throughput, not single-domain CFD scaling.
+  cuda: >-
+    CUDA remains outside the first paper because its pressure solver is not yet
+    numerically equivalent to the CPU implementations.
+
+physics:
+  problem: two_dimensional_lid_driven_cavity
+  cavity_length: 1.0
+  lid_velocity: 1.0
+  density: 1.0
+  precision: float64
+  reynolds_numbers: [100, 400, 1000]
+
+numerics:
+  method_name: explicit_pressure_correction
+  grid: uniform_cartesian_collocated
+  grid_sizes: [33, 65, 129, 257]
+  convection_scheme: central
+  diffusion_scheme: central
+  pressure_solver: RBSOR
+  pressure_initial_guess: previous_outer_correction
+  time_step:
+    type: adaptive_pseudo_time
+    cfl: 0.25
+  stopping_criteria:
+    velocity_update_linf: 1.0e-8
+    maximum_divergence: 1.0e-6
+    poisson_relative_residual: 1.0e-8
+    require_pressure_convergence: true
+    require_all_outer_criteria: true
+  iteration_limits:
+    outer_maximum: 50000
+    poisson_maximum: 5000
+  note: >-
+    Tolerances are initial paper targets and must be confirmed by a tolerance
+    sensitivity study before the benchmark is frozen.
+
+result_status_fields:
+  - execution_status
+  - outer_converged
+  - pressure_converged
+  - validation_status
+
+validation:
+  benchmark: Ghia_1982
+  sample_exact_centerlines: true
+  report_metrics:
+    - u_centerline_l1
+    - u_centerline_l2
+    - u_centerline_linf
+    - v_centerline_l1
+    - v_centerline_l2
+    - v_centerline_linf
+    - primary_vortex_center
+  verification:
+    operator_tests: true
+    systematic_grid_refinement: true
+
+performance:
+  warmup_runs: 1
+  measured_repetitions: 5
+  timed_output: disabled
+  report:
+    - solver_runtime_seconds
+    - runtime_per_outer_iteration
+    - pressure_solver_runtime_seconds
+    - outer_iterations
+    - total_poisson_iterations
+    - median
+    - interquartile_range
+  exclude_from_runtime_ranking:
+    - non_converged_cases
+    - runs_with_missing_metadata
+
+pilot_data:
+  current_long_running_jobs_label: pilot_v0
+  use_for_final_ranking: false
+  retain_for:
+    - convergence_diagnosis
+    - runtime_estimation
+    - pressure_solver_diagnosis

--- a/cpp/serial/Makefile
+++ b/cpp/serial/Makefile
@@ -1,10 +1,10 @@
 CXX ?= g++
-CXXFLAGS ?= -std=c++17 -O2  -Wall -Wextra -pedantic -g0
+CXXFLAGS ?= -std=c++17 -O2 -Wall -Wextra -pedantic -g0
 NO_FIELDS ?= 0
 NO_FIELDS_FLAG := $(if $(filter 1 true yes,$(NO_FIELDS)),--no-fields,)
 BIN = bin/lid_cavity
 
-.PHONY: build run smoke quick medium full plot clean
+.PHONY: build run smoke quick medium full paper paper-single plot clean
 
 build:
 	mkdir -p bin
@@ -24,6 +24,12 @@ medium: build
 
 full: build
 	$(BIN) --mode full $(NO_FIELDS_FLAG)
+
+paper: build
+	$(BIN) --mode paper $(NO_FIELDS_FLAG)
+
+paper-single: build
+	$(BIN) --single --N $(or $(N),65) --Re $(or $(RE),100) --scheme $(or $(SCHEME),central) --pressure $(or $(PRESSURE),RBSOR) --paper-protocol $(NO_FIELDS_FLAG)
 
 plot:
 	python3 postprocess/plot_results.py --all-cases --summaries all

--- a/cpp/serial/src/app/cli.cpp
+++ b/cpp/serial/src/app/cli.cpp
@@ -1,3 +1,21 @@
+static void configure_paper_protocol(Config& cfg) {
+    cfg.paper_protocol = true;
+    cfg.use_divergence_convergence = true;
+    cfg.require_pressure_convergence = true;
+
+    cfg.maxIter = 50000;
+    cfg.maxIter_N128_bonus = 0;
+    cfg.maxIter_Re1000_bonus = 0;
+    cfg.maxIter_central_bonus = 0;
+
+    cfg.tol_velocity = 1e-8;
+    cfg.tol_divergence = 1e-6;
+    cfg.poisson_tol_abs = 1e-10;
+    cfg.poisson_tol_rel = 1e-8;
+    cfg.poisson_check_every = 10;
+    cfg.poisson_maxIter = 5000;
+}
+
 static void configure_mode(Config& cfg, const std::string& mode) {
     const std::string m = lower(mode);
     if (m == "quick") {
@@ -15,7 +33,14 @@ static void configure_mode(Config& cfg, const std::string& mode) {
         cfg.maxIter_N128_bonus = 0;
         cfg.poisson_maxIter = 1800;
     } else if (m == "full") {
-        // defaults, equivalent to main.m
+        // Defaults, equivalent to the current full repository study.
+    } else if (m == "paper") {
+        cfg.meshes = {33, 65, 129, 257};
+        cfg.re_list = {100, 400, 1000};
+        cfg.schemes = {"central"};
+        cfg.pressure_solvers = {"RBSOR"};
+        cfg.implementations = {"serial_cpp"};
+        configure_paper_protocol(cfg);
     } else if (m == "single") {
         cfg.meshes = {64};
         cfg.re_list = {100};
@@ -34,18 +59,19 @@ static void configure_mode(Config& cfg, const std::string& mode) {
         cfg.maxIter_central_bonus = 0;
         cfg.poisson_maxIter = 50;
     } else {
-        throw std::runtime_error("Unknown mode: " + mode + " (use quick, medium, full, single, or smoke)");
+        throw std::runtime_error("Unknown mode: " + mode + " (use quick, medium, full, paper, single, or smoke)");
     }
 }
 
 static void print_usage(const char* exe) {
     std::cout << "Usage:\n"
-              << "  " << exe << " --mode quick|medium|full|single|smoke\n"
-              << "  " << exe << " --single --N 64 --Re 100 --scheme central --pressure RBGS --implementation serial_cpp\n\n"
+              << "  " << exe << " --mode quick|medium|full|paper|single|smoke\n"
+              << "  " << exe << " --single --N 65 --Re 100 --scheme central --pressure RBSOR --paper-protocol\n\n"
               << "Options:\n"
+              << "  --paper-protocol         Apply the draft paper convergence protocol to a selected case\n"
               << "  --no-fields              Do not write full field CSV files\n"
-              << "  --maxIter VALUE          Override base outer iterations\n"
-              << "  --poisson-maxIter VALUE  Override pressure solver iterations\n"
+              << "  --maxIter VALUE          Override base outer iterations after mode configuration\n"
+              << "  --poisson-maxIter VALUE  Override pressure solver iterations after mode configuration\n"
               << "\nImplementation note: this C++ package has one serial_cpp solver. MATLAB labels loop/vectorized are accepted as aliases only.\n";
 }
 
@@ -55,11 +81,14 @@ int main(int argc, char** argv) {
     Config cfg;
     std::string mode = "quick";
     bool explicit_single = false;
+    bool paper_protocol_requested = false;
     int single_N = 64;
     int single_Re = 100;
     std::string single_scheme = "central";
     std::string single_pressure = "RBGS";
     std::string single_implementation = "serial_cpp";
+    int max_iter_override = -1;
+    int poisson_max_iter_override = -1;
 
     try {
         for (int i = 1; i < argc; ++i) {
@@ -97,18 +126,26 @@ int main(int argc, char** argv) {
                 single_implementation = require_value(arg);
                 explicit_single = true;
                 mode = "single";
+            } else if (arg == "--paper-protocol") {
+                paper_protocol_requested = true;
             } else if (arg == "--no-fields") {
                 cfg.save_fields = false;
             } else if (arg == "--maxIter") {
-                cfg.maxIter = std::stoi(require_value(arg));
+                max_iter_override = std::stoi(require_value(arg));
             } else if (arg == "--poisson-maxIter") {
-                cfg.poisson_maxIter = std::stoi(require_value(arg));
+                poisson_max_iter_override = std::stoi(require_value(arg));
             } else {
                 throw std::runtime_error("Unknown argument: " + arg);
             }
         }
 
         configure_mode(cfg, mode);
+        if (paper_protocol_requested && lower(mode) != "paper") {
+            configure_paper_protocol(cfg);
+        }
+        if (max_iter_override > 0) cfg.maxIter = max_iter_override;
+        if (poisson_max_iter_override > 0) cfg.poisson_maxIter = poisson_max_iter_override;
+
         if (explicit_single) {
             cfg.meshes = {single_N};
             cfg.re_list = {single_Re};
@@ -118,7 +155,9 @@ int main(int argc, char** argv) {
         }
 
         fs::create_directories(cfg.data_dir);
-        const fs::path summary_path = fs::path(cfg.data_dir) / ("study_summary_" + lower(mode) + ".csv");
+        std::string summary_label = lower(mode);
+        if (cfg.paper_protocol && lower(mode) == "single") summary_label = "paper_single";
+        const fs::path summary_path = fs::path(cfg.data_dir) / ("study_summary_" + summary_label + ".csv");
         std::ofstream summary(summary_path);
         write_summary_header(summary);
 
@@ -126,6 +165,7 @@ int main(int argc, char** argv) {
                          * cfg.pressure_solvers.size() * cfg.implementations.size());
         std::cout << "\nLID-DRIVEN CAVITY C++ SOLVER\n";
         std::cout << "Mode: " << mode << "\n";
+        std::cout << "Paper protocol: " << (cfg.paper_protocol ? "enabled" : "disabled") << "\n";
         std::cout << "Total simulations: " << nCases << "\n";
         std::cout << "Summary: " << summary_path.string() << "\n\n";
 
@@ -149,15 +189,17 @@ int main(int argc, char** argv) {
                             Result r = solve_lid_cavity(N, Re, scheme, pressure_solver, implementation, cfg);
                             Metrics metrics = validate_against_ghia(r, cfg);
                             const std::string quality = quality_label(r, metrics);
-                            write_summary_row(summary, case_id, r, metrics, quality);
+                            write_summary_row(summary, case_id, r, metrics, quality, cfg);
                             summary.flush();
                             write_history_csv(r, case_name, cfg);
                             if (cfg.save_fields) write_field_csv(r, case_name, cfg);
 
                             std::cout << "      status=" << r.status << " quality=" << quality
                                       << " iter=" << r.iterations << "/" << r.localMaxIter
-                                      << " Rc_mass=" << std::scientific << std::setprecision(3) << r.final_Rc_mass
-                                      << " Rc_div=" << r.final_Rc_div
+                                      << " dU=" << std::scientific << std::setprecision(3) << std::max(r.final_Ru, r.final_Rv)
+                                      << " div=" << r.final_Rc_div
+                                      << " pRel=" << r.final_poisson_relative_residual
+                                      << " pConv=" << (r.final_pressure_converged ? 1 : 0)
                                       << " runtime=" << std::fixed << std::setprecision(2) << r.runtime << "s"
                                       << " avgPiter=" << std::setprecision(1) << r.avg_poisson_iters
                                       << " pSat=" << std::setprecision(2) << r.pressure_saturation_ratio << "\n";

--- a/cpp/serial/src/common/common.cpp
+++ b/cpp/serial/src/common/common.cpp
@@ -73,6 +73,9 @@ struct Config {
     double validation_v_L2_limit_Re1000 = 0.180;
 
     bool save_fields = true;
+    bool paper_protocol = false;
+    bool use_divergence_convergence = false;
+    bool require_pressure_convergence = false;
     std::string results_dir = "results";
     std::string data_dir = "results/data";
 };
@@ -98,6 +101,8 @@ struct Result {
     std::vector<double> x, y;
     Matrix u, v, p, speed, vorticity;
 
+    // Ru/Rv and Rc_* remain for backward-compatible CSV consumers. They are
+    // velocity-update and divergence-derived quantities, not true momentum residuals.
     std::vector<double> Ru, Rv, Rc_mass, Rc_div, dt, poisson_relative_residual;
     std::vector<int> poisson_iters;
     std::vector<bool> poisson_converged;
@@ -106,6 +111,10 @@ struct Result {
     int localMaxIter = 0;
     double runtime = 0.0;
     std::string status = "maxIter";
+    bool execution_completed = false;
+    bool outer_converged = false;
+    bool final_pressure_converged = false;
+    double final_poisson_relative_residual = std::numeric_limits<double>::infinity();
     double final_Ru = 0.0;
     double final_Rv = 0.0;
     double final_Rc_mass = 0.0;
@@ -170,4 +179,3 @@ static bool all_finite(const Matrix& m) {
     }
     return true;
 }
-

--- a/cpp/serial/src/core/solver.cpp
+++ b/cpp/serial/src/core/solver.cpp
@@ -96,7 +96,13 @@ static Result solve_lid_cavity(int N, int Re, std::string scheme, std::string pr
         }
         prev_mass = Rc_mass;
 
-        if (Rc_mass < cfg.tol_mass && std::max(Ru, Rv) < cfg.tol_velocity) {
+        const bool velocity_converged = std::max(Ru, Rv) < cfg.tol_velocity;
+        const bool continuity_converged = cfg.use_divergence_convergence
+            ? Rc_div < cfg.tol_divergence
+            : Rc_mass < cfg.tol_mass;
+        const bool pressure_converged = !cfg.require_pressure_convergence || pinfo.converged;
+
+        if (velocity_converged && continuity_converged && pressure_converged) {
             status = "converged";
             break;
         }
@@ -111,6 +117,8 @@ static Result solve_lid_cavity(int N, int Re, std::string scheme, std::string pr
 
     result.iterations = iter;
     result.status = status;
+    result.execution_completed = status != "diverged";
+    result.outer_converged = status == "converged";
     result.stagnation_counter = stagnation_counter;
 
     result.x.resize(N);
@@ -135,6 +143,10 @@ static Result solve_lid_cavity(int N, int Re, std::string scheme, std::string pr
     result.final_Rv = result.Rv.empty() ? 0.0 : result.Rv.back();
     result.final_Rc_mass = result.Rc_mass.empty() ? 0.0 : result.Rc_mass.back();
     result.final_Rc_div = result.Rc_div.empty() ? 0.0 : result.Rc_div.back();
+    result.final_pressure_converged = result.poisson_converged.empty() ? false : result.poisson_converged.back();
+    result.final_poisson_relative_residual = result.poisson_relative_residual.empty()
+        ? std::numeric_limits<double>::infinity()
+        : result.poisson_relative_residual.back();
 
     if (!result.poisson_iters.empty()) {
         result.avg_poisson_iters = std::accumulate(result.poisson_iters.begin(), result.poisson_iters.end(), 0.0)
@@ -148,4 +160,3 @@ static Result solve_lid_cavity(int N, int Re, std::string scheme, std::string pr
 
     return result;
 }
-

--- a/cpp/serial/src/post/output.cpp
+++ b/cpp/serial/src/post/output.cpp
@@ -1,8 +1,13 @@
+static std::string validation_status(const Metrics& metrics) {
+    if (!metrics.available) return "not_available";
+    return metrics.pass ? "passed" : "failed";
+}
+
 static std::string quality_label(const Result& result, const Metrics& metrics) {
-    if (result.status == "converged" && metrics.available && metrics.pass) return "converged_validated";
-    if (result.status == "converged" && metrics.available && !metrics.pass) return "converged_not_validated";
-    if (result.status == "converged" && !metrics.available) return "converged_no_benchmark";
-    if (result.status != "converged" && metrics.available && metrics.pass) return "validated_but_not_converged";
+    if (result.outer_converged && metrics.available && metrics.pass) return "converged_validated";
+    if (result.outer_converged && metrics.available && !metrics.pass) return "converged_not_validated";
+    if (result.outer_converged && !metrics.available) return "converged_no_benchmark";
+    if (!result.outer_converged && metrics.available && metrics.pass) return "validated_but_not_converged";
     return "needs_improvement";
 }
 
@@ -26,9 +31,11 @@ static void write_history_csv(const Result& r, const std::string& case_name, con
     const fs::path path = fs::path(cfg.data_dir) / (case_name + "_history.csv");
     std::ofstream out(path);
     out << std::setprecision(12);
-    out << "iter,Ru,Rv,Rc_mass,Rc_div,dt,poisson_iters,poisson_relative_residual,poisson_converged\n";
+    out << "iter,Ru,Rv,Rc_mass,Rc_div,VelocityUpdateU,VelocityUpdateV,MassResidual,MaxDivergence,"
+        << "dt,poisson_iters,poisson_relative_residual,poisson_converged\n";
     for (size_t k = 0; k < r.Ru.size(); ++k) {
         out << (k + 1) << ',' << r.Ru[k] << ',' << r.Rv[k] << ',' << r.Rc_mass[k] << ',' << r.Rc_div[k]
+            << ',' << r.Ru[k] << ',' << r.Rv[k] << ',' << r.Rc_mass[k] << ',' << r.Rc_div[k]
             << ',' << r.dt[k] << ',' << r.poisson_iters[k] << ',' << r.poisson_relative_residual[k]
             << ',' << (r.poisson_converged[k] ? 1 : 0) << '\n';
     }
@@ -38,16 +45,29 @@ static void write_summary_header(std::ofstream& out) {
     out << "CaseID,Implementation,N,Re,Scheme,PressureSolver,Status,Quality,Iterations,LocalMaxIter,"
         << "FinalRu,FinalRv,FinalRcMass,FinalRcDiv,Runtime_s,AvgPoissonIterations,"
         << "AvgPoissonRelResidual,PressureSaturationRatio,HasGhia,ValidationPass,"
-        << "Ghia_u_L2,Ghia_v_L2,Ghia_u_Linf,Ghia_v_Linf,Ghia_u_L2_Limit,Ghia_v_L2_Limit\n";
+        << "Ghia_u_L2,Ghia_v_L2,Ghia_u_Linf,Ghia_v_Linf,Ghia_u_L2_Limit,Ghia_v_L2_Limit,"
+        << "ExecutionCompleted,OuterConverged,PressureConverged,ValidationStatus,"
+        << "FinalVelocityUpdateU,FinalVelocityUpdateV,FinalMassResidual,FinalMaxDivergence,"
+        << "FinalPoissonRelResidual,ConvergenceProtocol\n";
 }
 
-static void write_summary_row(std::ofstream& out, int case_id, const Result& r, const Metrics& m, const std::string& quality) {
+static void write_summary_row(
+    std::ofstream& out,
+    int case_id,
+    const Result& r,
+    const Metrics& m,
+    const std::string& quality,
+    const Config& cfg
+) {
     out << std::setprecision(12);
     out << case_id << ',' << r.implementation << ',' << r.N << ',' << r.Re << ',' << r.scheme << ',' << r.pressure_solver << ','
         << r.status << ',' << quality << ',' << r.iterations << ',' << r.localMaxIter << ','
         << r.final_Ru << ',' << r.final_Rv << ',' << r.final_Rc_mass << ',' << r.final_Rc_div << ',' << r.runtime << ','
         << r.avg_poisson_iters << ',' << r.avg_poisson_relative_residual << ',' << r.pressure_saturation_ratio << ','
         << (m.available ? 1 : 0) << ',' << (m.pass ? 1 : 0) << ','
-        << m.u_L2 << ',' << m.v_L2 << ',' << m.u_Linf << ',' << m.v_Linf << ',' << m.u_limit << ',' << m.v_limit << '\n';
+        << m.u_L2 << ',' << m.v_L2 << ',' << m.u_Linf << ',' << m.v_Linf << ',' << m.u_limit << ',' << m.v_limit << ','
+        << (r.execution_completed ? 1 : 0) << ',' << (r.outer_converged ? 1 : 0) << ','
+        << (r.final_pressure_converged ? 1 : 0) << ',' << validation_status(m) << ','
+        << r.final_Ru << ',' << r.final_Rv << ',' << r.final_Rc_mass << ',' << r.final_Rc_div << ','
+        << r.final_poisson_relative_residual << ',' << (cfg.paper_protocol ? "paper_v1_draft" : "legacy") << '\n';
 }
-

--- a/docs/PAPER_ROADMAP.md
+++ b/docs/PAPER_ROADMAP.md
@@ -32,6 +32,15 @@ The contribution is the transparent cross-language implementation, numerical-equ
 
 The MATLAB and Octave code remains in the repository as previous work, but is not required for the paper because it cannot be executed consistently on Stromboli.
 
+## Stromboli operating rule
+
+Stromboli is a run-only machine for this project. Do not clone, initialize, fetch,
+pull, checkout, switch branches, create worktrees, or commit with Git there.
+
+Prepare a source-only archive locally, transfer it with `scp`, extract each
+snapshot into a separate timestamped directory, and return results with `scp` or
+`rsync`. See [`STROMBOLI_NO_GIT.md`](STROMBOLI_NO_GIT.md).
+
 ## Phase 0 — Preserve current work
 
 - [ ] Allow already-running jobs to finish.
@@ -41,7 +50,13 @@ The MATLAB and Octave code remains in the repository as previous work, but is no
 
 ## Phase 1 — Confirm available software
 
-Run on Stromboli:
+Package the branch locally with:
+
+```bash
+python3 scripts/package_paper_snapshot.py
+```
+
+Copy and extract the snapshot on Stromboli without Git, then run:
 
 ```bash
 bash scripts/check_paper_toolchain.sh \
@@ -85,8 +100,8 @@ Required changes:
 - [ ] Rename velocity-change quantities so they are not called momentum residuals.
 - [ ] Tighten and consistently report the pressure Poisson residual.
 - [ ] Reuse a previous pressure-correction estimate where appropriate.
-- [ ] Require pressure convergence in the outer convergence decision.
-- [ ] Add explicit booleans for outer and pressure convergence.
+- [x] Require pressure convergence in the paper-protocol outer convergence decision.
+- [x] Add explicit booleans for outer and pressure convergence.
 - [ ] Export solver time separately from file-output time.
 - [ ] Export complete run metadata.
 - [ ] Demonstrate stable, repeatable convergence for the first target case.
@@ -143,7 +158,7 @@ After running the toolchain check:
 - [ ] Use at least five measured repetitions.
 - [ ] Disable field output inside timed sections.
 - [ ] Preserve every raw timing.
-- [ ] Record compiler, interpreter, node, CPU, commit, thread, and rank metadata.
+- [ ] Record compiler, interpreter, node, CPU, source snapshot, thread, and rank metadata.
 - [ ] Exclude non-converged runs from performance ranking.
 - [ ] Report median and interquartile range.
 
@@ -157,4 +172,4 @@ After running the toolchain check:
 
 ## Immediate next task
 
-The next code change should be limited to the C++ serial solver and its output schema. The immediate success condition is one fully converged `N=65`, `Re=100`, central/RBSOR result with separate pressure and outer convergence reporting.
+The next numerical change should remain limited to the C++ serial solver and its output schema. The immediate success condition is one fully converged `N=65`, `Re=100`, central/RBSOR result with separate pressure and outer convergence reporting.

--- a/docs/PAPER_ROADMAP.md
+++ b/docs/PAPER_ROADMAP.md
@@ -158,7 +158,7 @@ After running the toolchain check:
 - [ ] Use at least five measured repetitions.
 - [ ] Disable field output inside timed sections.
 - [ ] Preserve every raw timing.
-- [ ] Record compiler, interpreter, node, CPU, source snapshot, thread, and rank metadata.
+- [ ] Record compiler, interpreter, node, CPU, snapshot identifier, thread, and rank metadata.
 - [ ] Exclude non-converged runs from performance ranking.
 - [ ] Report median and interquartile range.
 

--- a/docs/PAPER_ROADMAP.md
+++ b/docs/PAPER_ROADMAP.md
@@ -1,0 +1,160 @@
+# Paper development roadmap
+
+## Goal
+
+Build a simple, reproducible software paper comparing the same lid-driven-cavity pressure-correction algorithm across Python, C, C++, and optional Rust, with OpenFOAM as an external reference.
+
+The contribution is the transparent cross-language implementation, numerical-equivalence testing, and reproducible performance study. The cavity algorithm itself is not claimed as new.
+
+## Scope decision
+
+### Main benchmark
+
+- Python/NumPy serial
+- C serial
+- C++ serial
+- Rust serial if available on the target system
+- C/OpenMP
+- C++/OpenMP
+- Rust/Rayon if Rust is available
+
+### Separate analyses
+
+- Existing MPI implementations: parameter-sweep throughput
+- OpenFOAM: external engineering reference
+
+### Outside the first paper
+
+- MATLAB and Octave
+- CUDA
+- True spatial-domain MPI decomposition
+- Additional languages
+
+The MATLAB and Octave code remains in the repository as previous work, but is not required for the paper because it cannot be executed consistently on Stromboli.
+
+## Phase 0 — Preserve current work
+
+- [ ] Allow already-running jobs to finish.
+- [ ] Copy their complete outputs into a clearly labelled `pilot_v0` dataset.
+- [ ] Preserve logs, Slurm job IDs, node names, and failure information.
+- [ ] Do not use pilot timings as the final paper ranking.
+
+## Phase 1 — Confirm available software
+
+Run on Stromboli:
+
+```bash
+bash scripts/check_paper_toolchain.sh \
+  --output comparison/results/toolchain/stromboli.txt
+```
+
+Decision rules:
+
+- Rust joins the main paper only when both `rustc` and `cargo` are available or a documented user-space installation is used for every final run.
+- OpenFOAM joins only when a reproducible version and environment can be loaded.
+- Python, GCC, G++, Make, OpenMPI, and Slurm remain the required baseline.
+
+## Phase 2 — Freeze the numerical specification
+
+- [x] Add the draft paper case matrix.
+- [x] Use odd grids: `33`, `65`, `129`, `257`.
+- [x] Use central convection and RBSOR for the primary comparison.
+- [x] Separate execution, convergence, pressure, and validation status.
+- [ ] Confirm final tolerances using a sensitivity study.
+- [ ] Confirm one common SOR relaxation strategy.
+- [ ] Freeze the specification before running final timings.
+
+See:
+
+- `benchmark/paper_cases.yaml`
+- `benchmark/NUMERICAL_SPECIFICATION.md`
+
+## Phase 3 — Repair the C++ serial reference
+
+First target:
+
+```text
+N = 65
+Re = 100
+Scheme = central
+Pressure solver = RBSOR
+```
+
+Required changes:
+
+- [ ] Rename velocity-change quantities so they are not called momentum residuals.
+- [ ] Tighten and consistently report the pressure Poisson residual.
+- [ ] Reuse a previous pressure-correction estimate where appropriate.
+- [ ] Require pressure convergence in the outer convergence decision.
+- [ ] Add explicit booleans for outer and pressure convergence.
+- [ ] Export solver time separately from file-output time.
+- [ ] Export complete run metadata.
+- [ ] Demonstrate stable, repeatable convergence for the first target case.
+
+Do not port unfinished numerical changes to every language. Fix and validate the C++ reference first.
+
+## Phase 4 — Verification and validation
+
+- [ ] Add analytical derivative tests.
+- [ ] Add Laplacian and Poisson tests.
+- [ ] Add divergence-free-field and vorticity tests.
+- [ ] Add boundary-condition tests.
+- [ ] Sample exact cavity centerlines.
+- [ ] Report L1, L2, and Linf Ghia errors.
+- [ ] Report primary-vortex location.
+- [ ] Show systematic grid trends.
+
+## Phase 5 — Synchronize existing languages
+
+Port the frozen C++ behaviour to:
+
+- [ ] C serial
+- [ ] Python/NumPy serial
+- [ ] C/OpenMP
+- [ ] C++/OpenMP
+
+Acceptance condition:
+
+- Matched converged fields agree within documented floating-point tolerances.
+- Parallel and serial variants produce equivalent physical results.
+
+## Phase 6 — Rust decision and implementation
+
+After running the toolchain check:
+
+- [ ] Record whether Rust is available on Stromboli.
+- [ ] If available, add `rust_serial` using a flat `Vec<f64>` layout.
+- [ ] Validate Rust against C++ field outputs.
+- [ ] Add `rust_rayon` only after serial equivalence is established.
+- [ ] If unavailable, remove Rust from the final headline rather than running it on incomparable hardware.
+
+## Phase 7 — OpenFOAM reference
+
+- [ ] Confirm the installed OpenFOAM distribution and version.
+- [ ] Create equivalent Re 100, 400, and 1000 cases.
+- [ ] Match geometry, lid speed, viscosity, and approximate grids.
+- [ ] Export exact centerline profiles and vortex information.
+- [ ] Record end-to-end and solver runtimes.
+- [ ] Present OpenFOAM separately from the identical-algorithm comparison.
+
+## Phase 8 — Final benchmark runs
+
+- [ ] Use one warm-up run.
+- [ ] Use at least five measured repetitions.
+- [ ] Disable field output inside timed sections.
+- [ ] Preserve every raw timing.
+- [ ] Record compiler, interpreter, node, CPU, commit, thread, and rank metadata.
+- [ ] Exclude non-converged runs from performance ranking.
+- [ ] Report median and interquartile range.
+
+## Phase 9 — Paper and release
+
+- [ ] Generate every final table and figure from scripts.
+- [ ] Add the manuscript source under `paper/`.
+- [ ] Create a tagged `v1.0.0` release.
+- [ ] Update `CITATION.cff` with the release version and date.
+- [ ] Archive the software release and final data.
+
+## Immediate next task
+
+The next code change should be limited to the C++ serial solver and its output schema. The immediate success condition is one fully converged `N=65`, `Re=100`, central/RBSOR result with separate pressure and outer convergence reporting.

--- a/docs/STROMBOLI_NO_GIT.md
+++ b/docs/STROMBOLI_NO_GIT.md
@@ -46,7 +46,14 @@ when available locally, the source commit identifier.
 
 ## 2. Copy the snapshot to Stromboli
 
-From PowerShell, WSL, Linux, or macOS, replace the local file names as needed:
+Create the upload directory first:
+
+```bash
+ssh m2328670@stromboli.physik.uni-wuppertal.de "mkdir -p ~/uploads"
+```
+
+Then copy the archive, checksum, and extraction helper from PowerShell, WSL,
+Linux, or macOS:
 
 ```bash
 scp dist/lidcavity-paper-snapshot-*.tar.gz \
@@ -54,12 +61,9 @@ scp dist/lidcavity-paper-snapshot-*.tar.gz \
 
 scp dist/lidcavity-paper-snapshot-*.tar.gz.sha256 \
   m2328670@stromboli.physik.uni-wuppertal.de:~/uploads/
-```
 
-Create `~/uploads` first when necessary:
-
-```bash
-ssh m2328670@stromboli.physik.uni-wuppertal.de "mkdir -p ~/uploads"
+scp scripts/unpack_paper_snapshot.sh \
+  m2328670@stromboli.physik.uni-wuppertal.de:~/uploads/
 ```
 
 This uses SSH and SCP only. It does not use Git on Stromboli.
@@ -76,7 +80,10 @@ bash ~/uploads/unpack_paper_snapshot.sh \
   /beegfs/kandil/paper_runs
 ```
 
-When the helper script itself was not copied separately, extract directly:
+The helper verifies the SHA-256 checksum when the sidecar file is present and
+extracts the source into a new timestamped directory.
+
+Direct extraction is also possible:
 
 ```bash
 run_dir=/beegfs/kandil/paper_runs/LidCavity_Paper_$(date -u +%Y%m%dT%H%M%SZ)

--- a/docs/STROMBOLI_NO_GIT.md
+++ b/docs/STROMBOLI_NO_GIT.md
@@ -1,0 +1,142 @@
+# Stromboli deployment without Git
+
+Stromboli is treated as a run-only machine for the paper benchmark.
+
+Do not run any of the following commands on Stromboli:
+
+```text
+git clone
+git init
+git fetch
+git pull
+git checkout
+git switch
+git worktree
+```
+
+The source snapshot is prepared on another machine, copied with `scp`, and
+extracted into a separate run directory. Existing Stromboli result directories
+and running Slurm jobs are not touched.
+
+## 1. Prepare the source snapshot locally
+
+On the local checkout of the paper branch:
+
+```bash
+python3 scripts/package_paper_snapshot.py
+```
+
+The script creates two files under `dist/`:
+
+```text
+lidcavity-paper-snapshot-<UTC timestamp>.tar.gz
+lidcavity-paper-snapshot-<UTC timestamp>.tar.gz.sha256
+```
+
+The archive excludes:
+
+- `.git` and other editor metadata
+- existing result and figure trees
+- binaries and object files
+- Python virtual environments and caches
+- old archives
+
+The archive contains a `SNAPSHOT_MANIFEST.json` file with the creation time and,
+when available locally, the source commit identifier.
+
+## 2. Copy the snapshot to Stromboli
+
+From PowerShell, WSL, Linux, or macOS, replace the local file names as needed:
+
+```bash
+scp dist/lidcavity-paper-snapshot-*.tar.gz \
+  m2328670@stromboli.physik.uni-wuppertal.de:~/uploads/
+
+scp dist/lidcavity-paper-snapshot-*.tar.gz.sha256 \
+  m2328670@stromboli.physik.uni-wuppertal.de:~/uploads/
+```
+
+Create `~/uploads` first when necessary:
+
+```bash
+ssh m2328670@stromboli.physik.uni-wuppertal.de "mkdir -p ~/uploads"
+```
+
+This uses SSH and SCP only. It does not use Git on Stromboli.
+
+## 3. Extract into a separate run directory
+
+On Stromboli:
+
+```bash
+mkdir -p /beegfs/kandil/paper_runs
+
+bash ~/uploads/unpack_paper_snapshot.sh \
+  ~/uploads/lidcavity-paper-snapshot-<timestamp>.tar.gz \
+  /beegfs/kandil/paper_runs
+```
+
+When the helper script itself was not copied separately, extract directly:
+
+```bash
+run_dir=/beegfs/kandil/paper_runs/LidCavity_Paper_$(date -u +%Y%m%dT%H%M%SZ)
+mkdir -p "$run_dir"
+tar -xzf ~/uploads/lidcavity-paper-snapshot-<timestamp>.tar.gz \
+  -C "$run_dir" --strip-components=1
+cd "$run_dir"
+```
+
+Every upload should receive its own timestamped directory. Do not overwrite the
+folder used by currently running jobs.
+
+## 4. Check the available tools
+
+From the extracted directory:
+
+```bash
+bash scripts/check_paper_toolchain.sh \
+  --output comparison/results/toolchain/stromboli.txt
+
+cat comparison/results/toolchain/stromboli.txt
+```
+
+This determines whether Rust and OpenFOAM are available without installing or
+changing anything.
+
+Rust is included in the paper only when both `rustc` and `cargo` are available.
+OpenFOAM is included only when its commands and environment are accessible.
+Python, C, and C++ remain the guaranteed core comparison.
+
+## 5. Run through Slurm
+
+Do not launch full paper cases on a login node. First prepare a one-case Slurm
+job for:
+
+```text
+N = 65
+Re = 100
+scheme = central
+pressure solver = RBSOR
+implementation = C++ serial
+```
+
+The run must write into its own directory under:
+
+```text
+comparison/results/paper_v1/raw/
+```
+
+The existing pilot jobs and result folders are left unchanged.
+
+## 6. Return results without Git
+
+Copy the completed result folder back using `scp` or `rsync`:
+
+```bash
+scp -r \
+  m2328670@stromboli.physik.uni-wuppertal.de:/beegfs/kandil/paper_runs/<run>/comparison/results/paper_v1/raw \
+  ./stromboli_results/
+```
+
+Results are reviewed and committed from the local development environment, not
+from Stromboli.

--- a/docs/WIKI_INDEX.md
+++ b/docs/WIKI_INDEX.md
@@ -9,11 +9,12 @@ This work-in-progress repository keeps version-controlled documentation in `docs
 | [`PAPER_ROADMAP.md`](PAPER_ROADMAP.md) | Staged plan for turning the project into a reproducible software and benchmark paper |
 | [`../benchmark/NUMERICAL_SPECIFICATION.md`](../benchmark/NUMERICAL_SPECIFICATION.md) | Draft frozen numerical method, validation protocol, language scope, and timing rules for the paper |
 | [`../benchmark/paper_cases.yaml`](../benchmark/paper_cases.yaml) | Machine-readable draft paper case matrix and convergence targets |
+| [`STROMBOLI_NO_GIT.md`](STROMBOLI_NO_GIT.md) | Required snapshot, SCP, extraction, execution, and result-return workflow without using Git on Stromboli |
 | [`CURRENT_BENCHMARK_RESULTS.md`](CURRENT_BENCHMARK_RESULTS.md) | Current dataset, interim runtime measurements, convergence interpretation, and remaining work |
 | [`PROJECT_OVERVIEW.md`](PROJECT_OVERVIEW.md) | Project and numerical-method overview |
 | [`IMPLEMENTATION_LAYOUT.md`](IMPLEMENTATION_LAYOUT.md) | Folder layout and implementation structure |
 | [`RESULTS_GUIDE.md`](RESULTS_GUIDE.md) | Explanation of result files, CSV outputs, and plots |
-| [`RUNNING_ON_HPC.md`](RUNNING_ON_HPC.md) | Notes for Linux and HPC environments |
+| [`RUNNING_ON_HPC.md`](RUNNING_ON_HPC.md) | General notes for Linux and HPC environments |
 | [`HOW_TO_PRESENT_THIS_PROJECT.md`](HOW_TO_PRESENT_THIS_PROJECT.md) | Accurate wording for CVs, LinkedIn, interviews, and portfolio use |
 | [`COMMUNITY.md`](COMMUNITY.md) | Discussions categories, issue guidance, and community communication |
 
@@ -42,10 +43,11 @@ This work-in-progress repository keeps version-controlled documentation in `docs
 
 1. Read the root `README.md` for project scope and status.
 2. Read `PAPER_ROADMAP.md` and the benchmark numerical specification before changing solver behaviour or starting new final runs.
-3. Read `CURRENT_BENCHMARK_RESULTS.md` for the current pilot measurements and limitations.
-4. Check `comparison/figures/report_pngs/` for runtime and residual figures.
-5. Check `comparison/figures/physics_final/` for streamlines, vectors, contours, and centerline comparisons.
-6. Read `HOW_TO_PRESENT_THIS_PROJECT.md` before describing the project in a CV, interview, or public post.
+3. Read `STROMBOLI_NO_GIT.md` before transferring or running any paper code on Stromboli.
+4. Read `CURRENT_BENCHMARK_RESULTS.md` for the current pilot measurements and limitations.
+5. Check `comparison/figures/report_pngs/` for runtime and residual figures.
+6. Check `comparison/figures/physics_final/` for streamlines, vectors, contours, and centerline comparisons.
+7. Read `HOW_TO_PRESENT_THIS_PROJECT.md` before describing the project in a CV, interview, or public post.
 
 ## Why this is not a separate GitHub Wiki
 

--- a/docs/WIKI_INDEX.md
+++ b/docs/WIKI_INDEX.md
@@ -6,6 +6,9 @@ This work-in-progress repository keeps version-controlled documentation in `docs
 
 | Document | Purpose |
 |---|---|
+| [`PAPER_ROADMAP.md`](PAPER_ROADMAP.md) | Staged plan for turning the project into a reproducible software and benchmark paper |
+| [`../benchmark/NUMERICAL_SPECIFICATION.md`](../benchmark/NUMERICAL_SPECIFICATION.md) | Draft frozen numerical method, validation protocol, language scope, and timing rules for the paper |
+| [`../benchmark/paper_cases.yaml`](../benchmark/paper_cases.yaml) | Machine-readable draft paper case matrix and convergence targets |
 | [`CURRENT_BENCHMARK_RESULTS.md`](CURRENT_BENCHMARK_RESULTS.md) | Current dataset, interim runtime measurements, convergence interpretation, and remaining work |
 | [`PROJECT_OVERVIEW.md`](PROJECT_OVERVIEW.md) | Project and numerical-method overview |
 | [`IMPLEMENTATION_LAYOUT.md`](IMPLEMENTATION_LAYOUT.md) | Folder layout and implementation structure |
@@ -38,10 +41,11 @@ This work-in-progress repository keeps version-controlled documentation in `docs
 ## Suggested reading path
 
 1. Read the root `README.md` for project scope and status.
-2. Read `CURRENT_BENCHMARK_RESULTS.md` for the current measurements and limitations.
-3. Check `comparison/figures/report_pngs/` for runtime and residual figures.
-4. Check `comparison/figures/physics_final/` for streamlines, vectors, contours, and centerline comparisons.
-5. Read `HOW_TO_PRESENT_THIS_PROJECT.md` before describing the project in a CV, interview, or public post.
+2. Read `PAPER_ROADMAP.md` and the benchmark numerical specification before changing solver behaviour or starting new final runs.
+3. Read `CURRENT_BENCHMARK_RESULTS.md` for the current pilot measurements and limitations.
+4. Check `comparison/figures/report_pngs/` for runtime and residual figures.
+5. Check `comparison/figures/physics_final/` for streamlines, vectors, contours, and centerline comparisons.
+6. Read `HOW_TO_PRESENT_THIS_PROJECT.md` before describing the project in a CV, interview, or public post.
 
 ## Why this is not a separate GitHub Wiki
 

--- a/scripts/check_paper_toolchain.sh
+++ b/scripts/check_paper_toolchain.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+# Check which paper-benchmark tools are available without requiring sudo.
+# Run with:
+#   bash scripts/check_paper_toolchain.sh
+# or save the report with:
+#   bash scripts/check_paper_toolchain.sh --output comparison/results/toolchain/stromboli.txt
+
+set -uo pipefail
+
+OUTPUT=""
+if [[ ${1:-} == "--output" ]]; then
+    OUTPUT=${2:-}
+    if [[ -z "$OUTPUT" ]]; then
+        echo "error: --output requires a path" >&2
+        exit 2
+    fi
+    mkdir -p "$(dirname "$OUTPUT")"
+fi
+
+emit() {
+    printf '%s\n' "$*"
+}
+
+command_version() {
+    local label=$1
+    local command_name=$2
+    shift 2
+
+    if command -v "$command_name" >/dev/null 2>&1; then
+        emit "[available] $label"
+        emit "  path: $(command -v "$command_name")"
+        local version_output
+        version_output=$("$command_name" "$@" 2>&1 | head -n 3 || true)
+        if [[ -n "$version_output" ]]; then
+            while IFS= read -r line; do
+                emit "  $line"
+            done <<< "$version_output"
+        fi
+    else
+        emit "[missing]   $label ($command_name)"
+    fi
+}
+
+run_report() {
+    emit "LidCavity paper toolchain report"
+    emit "generated_utc: $(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+    emit "hostname: $(hostname 2>/dev/null || echo unknown)"
+    emit "kernel: $(uname -srmo 2>/dev/null || echo unknown)"
+    emit "working_directory: $(pwd)"
+    emit ""
+
+    emit "== Core serial toolchains =="
+    command_version "Python" python3 --version
+    command_version "GCC" gcc --version
+    command_version "G++" g++ --version
+    command_version "Make" make --version
+    emit ""
+
+    emit "== Rust check =="
+    command_version "Rust compiler" rustc --version
+    command_version "Cargo" cargo --version
+    emit ""
+
+    emit "== Parallel tooling =="
+    command_version "MPI compiler (C)" mpicc --version
+    command_version "MPI compiler (C++)" mpicxx --version
+    command_version "MPI launcher" mpirun --version
+    command_version "Slurm submit" sbatch --version
+    command_version "Slurm run" srun --version
+    emit ""
+
+    emit "== OpenFOAM check =="
+    command_version "OpenFOAM version helper" foamVersion
+    command_version "OpenFOAM generic runner" foamRun -help
+    command_version "OpenFOAM icoFoam" icoFoam -help
+    command_version "OpenFOAM simpleFoam" simpleFoam -help
+    command_version "OpenFOAM pimpleFoam" pimpleFoam -help
+    emit ""
+
+    emit "== Optional GPU tooling =="
+    command_version "CUDA compiler" nvcc --version
+    command_version "NVIDIA status" nvidia-smi --query-gpu=name,driver_version --format=csv,noheader
+    emit ""
+
+    emit "== Hardware summary =="
+    if command -v lscpu >/dev/null 2>&1; then
+        lscpu | grep -E '^(Architecture|CPU\(s\)|Model name|Thread\(s\) per core|Core\(s\) per socket|Socket\(s\)|NUMA node\(s\)):' || true
+    else
+        emit "lscpu unavailable"
+    fi
+    emit ""
+
+    emit "== Interpretation =="
+    if command -v rustc >/dev/null 2>&1 && command -v cargo >/dev/null 2>&1; then
+        emit "rust_status: available"
+    else
+        emit "rust_status: unavailable_on_current_path"
+    fi
+
+    if command -v foamVersion >/dev/null 2>&1 || command -v foamRun >/dev/null 2>&1 || command -v icoFoam >/dev/null 2>&1; then
+        emit "openfoam_status: available"
+    else
+        emit "openfoam_status: unavailable_or_environment_not_loaded"
+    fi
+}
+
+if [[ -n "$OUTPUT" ]]; then
+    run_report | tee "$OUTPUT"
+else
+    run_report
+fi

--- a/scripts/package_paper_snapshot.py
+++ b/scripts/package_paper_snapshot.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Create a source-only archive for running the paper benchmark on Stromboli.
+
+The archive intentionally excludes Git metadata, generated results, build outputs,
+virtual environments, caches, and previously created distribution archives.
+It can therefore be copied to Stromboli with scp and extracted without using Git
+on the cluster.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import tarfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+EXCLUDED_DIR_NAMES = {
+    ".git",
+    ".idea",
+    ".vscode",
+    ".venv",
+    "venv",
+    "env",
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+    "bin",
+    "build",
+    "dist",
+    "node_modules",
+}
+
+EXCLUDED_SUFFIXES = {
+    ".o",
+    ".obj",
+    ".so",
+    ".dll",
+    ".dylib",
+    ".exe",
+    ".pyc",
+    ".pyo",
+    ".log",
+}
+
+# Generated result trees can be very large and are not needed to launch a clean run.
+EXCLUDED_PATH_PARTS = {
+    ("comparison", "results"),
+    ("comparison", "figures"),
+    ("c", "serial", "results"),
+    ("c", "openmp", "results"),
+    ("c", "mpi", "results"),
+    ("cpp", "serial", "results"),
+    ("cpp", "openmp", "results"),
+    ("cpp", "mpi", "results"),
+    ("python", "serial", "results"),
+    ("python", "mpi", "results"),
+    ("matlab", "results"),
+    ("cuda", "results"),
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Package the current checkout for no-Git deployment to Stromboli."
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root. Defaults to the parent of scripts/.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Output .tar.gz path. Defaults to dist/lidcavity-paper-snapshot-<UTC timestamp>.tar.gz.",
+    )
+    return parser.parse_args()
+
+
+def path_starts_with(parts: tuple[str, ...], prefix: tuple[str, ...]) -> bool:
+    return len(parts) >= len(prefix) and parts[: len(prefix)] == prefix
+
+
+def should_exclude(relative_path: Path) -> bool:
+    parts = relative_path.parts
+    if any(part in EXCLUDED_DIR_NAMES for part in parts):
+        return True
+    if relative_path.suffix.lower() in EXCLUDED_SUFFIXES:
+        return True
+    if relative_path.name.endswith((".tar.gz", ".tgz", ".zip")):
+        return True
+    return any(path_starts_with(parts, prefix) for prefix in EXCLUDED_PATH_PARTS)
+
+
+def iter_source_files(root: Path) -> Iterable[Path]:
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(root)
+        if should_exclude(relative):
+            continue
+        yield path
+
+
+def optional_git_commit(root: Path) -> str | None:
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+    return completed.stdout.strip() or None
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def main() -> int:
+    args = parse_args()
+    root = args.root.resolve()
+    if not (root / "README.md").is_file():
+        raise SystemExit(f"Repository root not recognised: {root}")
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    output = (
+        args.output.resolve()
+        if args.output is not None
+        else (root / "dist" / f"lidcavity-paper-snapshot-{timestamp}.tar.gz")
+    )
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    files = sorted(iter_source_files(root), key=lambda path: path.as_posix())
+    manifest = {
+        "created_utc": datetime.now(timezone.utc).isoformat(),
+        "archive_format": "tar.gz",
+        "source_root_name": root.name,
+        "source_commit": optional_git_commit(root),
+        "file_count": len(files),
+        "deployment_policy": "No Git operations are required or expected on Stromboli.",
+    }
+
+    archive_root = "LidCavity_Paper"
+    with tarfile.open(output, mode="w:gz", format=tarfile.PAX_FORMAT) as archive:
+        for path in files:
+            relative = path.relative_to(root)
+            archive.add(path, arcname=str(Path(archive_root) / relative), recursive=False)
+
+        manifest_bytes = (json.dumps(manifest, indent=2) + "\n").encode("utf-8")
+        info = tarfile.TarInfo(name=f"{archive_root}/SNAPSHOT_MANIFEST.json")
+        info.size = len(manifest_bytes)
+        info.mtime = int(datetime.now(timezone.utc).timestamp())
+        info.mode = 0o644
+        import io
+
+        archive.addfile(info, io.BytesIO(manifest_bytes))
+
+    digest = sha256_file(output)
+    checksum_path = output.with_suffix(output.suffix + ".sha256")
+    checksum_path.write_text(f"{digest}  {output.name}\n", encoding="utf-8")
+
+    print(f"Created: {output}")
+    print(f"Checksum: {checksum_path}")
+    print(f"Files: {len(files)}")
+    print("Copy both files to Stromboli with scp; no Git is needed there.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/unpack_paper_snapshot.sh
+++ b/scripts/unpack_paper_snapshot.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/unpack_paper_snapshot.sh ARCHIVE.tar.gz [DESTINATION_PARENT]
+
+Example:
+  bash scripts/unpack_paper_snapshot.sh \
+    ~/uploads/lidcavity-paper-snapshot-20260724T080000Z.tar.gz \
+    /beegfs/kandil/paper_runs
+
+This script does not call Git. It verifies the optional SHA-256 sidecar when
+present, extracts the snapshot into a timestamped directory, and prints the
+resulting run path.
+EOF
+}
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  usage >&2
+  exit 2
+fi
+
+archive=$(readlink -f "$1")
+destination_parent=${2:-"${HOME}/paper_runs"}
+
+if [[ ! -f "$archive" ]]; then
+  echo "Archive not found: $archive" >&2
+  exit 1
+fi
+
+mkdir -p "$destination_parent"
+destination_parent=$(readlink -f "$destination_parent")
+
+checksum_file="${archive}.sha256"
+if [[ -f "$checksum_file" ]]; then
+  echo "Verifying checksum: $checksum_file"
+  (
+    cd "$(dirname "$archive")"
+    sha256sum -c "$(basename "$checksum_file")"
+  )
+else
+  echo "Warning: checksum sidecar not found; extraction will continue." >&2
+fi
+
+stamp=$(date -u +%Y%m%dT%H%M%SZ)
+run_dir="${destination_parent}/LidCavity_Paper_${stamp}"
+mkdir -p "$run_dir"
+
+tar -xzf "$archive" -C "$run_dir" --strip-components=1
+
+mkdir -p \
+  "$run_dir/comparison/results/toolchain" \
+  "$run_dir/comparison/results/paper_v1/raw" \
+  "$run_dir/comparison/results/paper_v1/processed" \
+  "$run_dir/logs"
+
+echo
+printf 'Snapshot extracted to:\n  %s\n' "$run_dir"
+echo "No Git repository or Git metadata is present or required."
+echo
+echo "Next safe check:"
+printf '  cd %q\n' "$run_dir"
+echo "  bash scripts/check_paper_toolchain.sh --output comparison/results/toolchain/stromboli.txt"


### PR DESCRIPTION
## What changed

- defines a narrow draft paper benchmark for Python, C, C++, and conditional Rust
- excludes MATLAB/Octave from the main Stromboli paper scope while retaining the existing implementations
- treats OpenFOAM as an external reference and MPI as parameter-sweep throughput
- adds a numerical specification with odd grids, separate convergence statuses, validation, verification, and timing rules
- adds a no-sudo Stromboli toolchain check for Rust, OpenFOAM, MPI, Slurm, and optional CUDA
- adds a staged implementation and publication roadmap
- adds a non-disruptive C++ serial `paper` protocol and `paper-single` target
- preserves legacy CSV fields while adding explicit execution, outer-convergence, pressure-convergence, and validation fields
- makes command-line iteration overrides apply after mode configuration
- establishes Stromboli as a run-only, no-Git environment
- adds source-only snapshot packaging, checksum generation, SCP deployment instructions, and a no-Git extraction helper

## Why

The current result set is valuable pilot data, but many cases reach their iteration limits. This branch isolates the work required to obtain converged, cross-language-equivalent, reproducible results before writing the paper.

## Stromboli rule

Do not run Git commands on Stromboli. Prepare the archive locally:

```bash
python3 scripts/package_paper_snapshot.py
```

Copy the archive, SHA-256 sidecar, and `scripts/unpack_paper_snapshot.sh` with `scp`, then extract each snapshot into a separate timestamped directory under `/beegfs/kandil/paper_runs`.

See `docs/STROMBOLI_NO_GIT.md`.

## First numerical milestone

After transferring the snapshot and confirming the toolchain, submit the C++ diagnostic through Slurm:

```bash
cd cpp/serial
make paper-single N=65 RE=100 NO_FIELDS=1
```

This milestone is not complete until the case satisfies the draft velocity-update, maximum-divergence, and pressure-residual criteria.

## Validation

- existing default smoke modes are preserved
- existing long-running jobs from `main` are unaffected
- deployment archives exclude `.git`, generated results, build files, and caches
- the PR remains draft while numerical convergence is being repaired